### PR TITLE
Fixed REALM_LIST packet structure.

### DIFF
--- a/src/lib/realms/handler.js
+++ b/src/lib/realms/handler.js
@@ -24,7 +24,10 @@ class RealmsHandler extends EventEmitter {
   refresh() {
     console.info('refreshing realmlist');
 
-    const ap = new AuthPacket(AuthOpcode.REALM_LIST);
+    const ap = new AuthPacket(AuthOpcode.REALM_LIST, 1 + 4);
+
+    // Per WoWDev, the opcode is followed by an unknown uint32
+    ap.writeUnsignedInt(0x00);
 
     return this.session.auth.send(ap);
   }


### PR DESCRIPTION
This corrects the REALM_LIST packet structure to include an unknown uint32 after the opcode. With the change, the packet should better match retail, and makes it possible to retrieve a realm list from TrinityCore's authserver.