### PR TITLE
More transparency / blending improvements

### DIFF
--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -51,9 +51,11 @@ class Submesh extends THREE.Mesh {
         break;
     }
 
-    const { renderFlags } = textureUnit;
+    this.applyRenderFlags(textureUnit.renderFlags);
+  }
 
-    // No backface culling.
+  applyRenderFlags(renderFlags) {
+    // Flag 0x04 - no backface culling
     if (renderFlags.flags & 0x04) {
       this.material.side = THREE.DoubleSide;
 
@@ -62,13 +64,14 @@ class Submesh extends THREE.Mesh {
       this.material.transparent = true;
     }
 
-    // TODO: Implement remaining blend modes (5, 6)
+    // Blending modes
     switch (renderFlags.blendingMode) {
       case 0:
         this.material.blending = THREE.NoBlending;
         this.material.blendSrc = THREE.OneFactor;
         this.material.blendDst = THREE.ZeroFactor;
         break;
+
       case 1:
         this.material.transparent = true;
 
@@ -80,24 +83,42 @@ class Submesh extends THREE.Mesh {
         this.material.blendSrcAlpha = THREE.OneFactor;
         this.material.blendDstAlpha = THREE.ZeroFactor;
         break;
+
       case 2:
         this.material.blendSrc = THREE.SrcAlphaFactor;
         this.material.blendDst = THREE.OneMinusSrcAlphaFactor;
         this.material.blendSrcAlpha = THREE.SrcAlphaFactor;
         this.material.blendDstAlpha = THREE.OneMinusSrcAlphaFactor;
         break;
+
       case 3:
         this.material.blendSrc = THREE.SrcColorFactor;
         this.material.blendDst = THREE.DstColorFactor;
         this.material.blendSrcAlpha = THREE.SrcAlphaFactor;
         this.material.blendDstAlpha = THREE.DstAlphaFactor;
         break;
+
       case 4:
         this.material.blendSrc = THREE.SrcAlphaFactor;
         this.material.blendDst = THREE.OneFactor;
         this.material.blendSrcAlpha = THREE.SrcAlphaFactor;
         this.material.blendDstAlpha = THREE.OneFactor;
         break;
+
+      case 5:
+        this.material.blendSrc = THREE.SrcAlphaFactor;
+        this.material.blendDst = THREE.OneMinusSrcAlphaFactor;
+        this.material.blendSrcAlpha = THREE.SrcAlphaFactor;
+        this.material.blendDstAlpha = THREE.OneMinusSrcAlphaFactor;
+        break;
+
+      case 6:
+        this.material.blendSrc = THREE.DstColorFactor;
+        this.material.blendDst = THREE.SrcColorFactor;
+        this.material.blendSrcAlpha = THREE.DstAlphaFactor;
+        this.material.blendDstAlpha = THREE.SrcAlphaFactor;
+        break;
+
       default:
         break;
     }

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -72,6 +72,9 @@ class Submesh extends THREE.Mesh {
       case 1:
         this.material.transparent = true;
 
+        this.material.alphaTest = 0.5;
+        this.material.side = THREE.DoubleSide;
+
         this.material.blendSrc = THREE.OneFactor;
         this.material.blendDst = THREE.ZeroFactor;
         this.material.blendSrcAlpha = THREE.OneFactor;

--- a/src/lib/pipeline/wmo/index.js
+++ b/src/lib/pipeline/wmo/index.js
@@ -18,7 +18,16 @@ class WMO extends THREE.Group {
     const textures = this.data.MOTX.filenames;
     const mats = this.data.MOMT.materials.map(function(materialData) {
       const material = new Material();
+
       material.texture = textures[materialData.textures[0].offset];
+
+      // Transparent blending
+      if (materialData.blendMode === 1) {
+        material.transparent = true;
+        material.alphaTest = 0.5;
+        material.side = THREE.DoubleSide;
+      }
+
       return material;
     });
 


### PR DESCRIPTION
I've implemented blending modes 5 and 6 for M2s, so that should be the full extend of blending modes involved with M2s. I haven't had a chance to find M2s that utilize anything beyond blending modes 0, 1, and 2, so there's a chance I have a few flaws in my implementation.

I've also added transparent rendering support to WMOs. I hope I put the logic in a reasonable place.