### PR TITLE
M2 bone billboarding support

### DIFF
--- a/src/components/game/index.jsx
+++ b/src/components/game/index.jsx
@@ -15,7 +15,7 @@ class GameScreen extends React.Component {
   constructor() {
     super();
 
-    this.update = ::this.update;
+    this.animate = ::this.animate;
     this.resize = ::this.resize;
 
     this.camera = new THREE.PerspectiveCamera(60, this.aspectRatio, 1, 1000);
@@ -33,7 +33,7 @@ class GameScreen extends React.Component {
     });
 
     this.resize();
-    this.update();
+    this.animate();
 
     window.addEventListener('resize', this.resize);
   }
@@ -62,7 +62,7 @@ class GameScreen extends React.Component {
     this.camera.updateProjectionMatrix();
   }
 
-  update() {
+  animate() {
     if (!this.renderer) {
       return;
     }
@@ -72,7 +72,7 @@ class GameScreen extends React.Component {
     session.world.animate(this.camera);
 
     this.renderer.render(session.world.scene, this.camera);
-    this.requestID = requestAnimationFrame(this.update);
+    this.requestID = requestAnimationFrame(this.animate);
   }
 
   render() {

--- a/src/components/game/index.jsx
+++ b/src/components/game/index.jsx
@@ -48,7 +48,7 @@ class GameScreen extends React.Component {
   animate() {
     this.refs.controls.update();
 
-    session.world.animate();
+    session.world.animate(this.camera);
 
     this.renderer.render(session.world.scene, this.camera);
     requestAnimationFrame(this.animate);

--- a/src/components/game/index.jsx
+++ b/src/components/game/index.jsx
@@ -47,6 +47,9 @@ class GameScreen extends React.Component {
 
   animate() {
     this.refs.controls.update();
+
+    session.world.animate();
+
     this.renderer.render(session.world.scene, this.camera);
     requestAnimationFrame(this.animate);
   }

--- a/src/components/game/index.jsx
+++ b/src/components/game/index.jsx
@@ -22,6 +22,8 @@ class GameScreen extends React.Component {
     this.camera.up.set(0, 0, 1);
     this.camera.position.set(15, 0, 7);
 
+    this.prevCameraRotation = null;
+
     this.renderer = null;
     this.requestID = null;
   }
@@ -69,10 +71,15 @@ class GameScreen extends React.Component {
 
     this.refs.controls.update();
 
-    session.world.animate(this.camera);
+    const cameraRotated = this.prevCameraRotation === null ||
+      !this.prevCameraRotation.equals(this.camera.quaternion);
+
+    session.world.animate(this.camera, cameraRotated);
 
     this.renderer.render(session.world.scene, this.camera);
     this.requestID = requestAnimationFrame(this.animate);
+
+    this.prevCameraRotation = this.camera.quaternion.clone();
   }
 
   render() {

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -37,7 +37,7 @@ class WorldHandler extends EventEmitter {
     this.billboardedM2s = [];
 
     // Darkshire (Eastern Kingdoms)
-    // this.player.worldport(0, -10559, -1189, 28);
+    this.player.worldport(0, -10559, -1189, 28);
 
     // Booty Bay (Eastern Kingdoms)
     // this.player.worldport(0, -14354, 518, 22);

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -101,51 +101,42 @@ class WorldHandler extends EventEmitter {
     const cameraRotated = this.prevCameraRotation === null ||
       !this.prevCameraRotation.equals(camera.quaternion);
 
-    this.animateModels(cameraRotated);
+    this.animateModels(camera, cameraRotated);
 
     this.prevCameraRotation = camera.quaternion.clone();
   }
 
-  animateModels(cameraRotated) {
+  animateModels(camera, cameraRotated) {
     if (cameraRotated) {
-      this.animateBillboards();
+      this.animateBillboards(camera);
     }
   }
 
-  animateBillboards() {
+  animateBillboards(camera) {
     this.billboards.forEach((billboard) => {
       const mesh = billboard[0];
-      const skeleton = mesh.skeleton;
       const boneIndex = billboard[1];
-      const pivotPoint = billboard[2];
+
+      const skeleton = mesh.skeleton;
       const bone = skeleton.bones[boneIndex];
 
       const mvMatrix = mesh.modelViewMatrix.elements;
       const viewRight = new THREE.Vector3(mvMatrix[0], mvMatrix[4], mvMatrix[8]);
       const viewUp = new THREE.Vector3(mvMatrix[1], mvMatrix[5], mvMatrix[9]);
+      const look = camera.getWorldDirection();
+
       viewRight.multiplyScalar(-1);
 
       const tMatrix = new THREE.Matrix4();
-      const t2Matrix = new THREE.Matrix4();
 
       tMatrix.set(
-        1,  viewUp.x,   viewRight.x,  pivotPoint.x,
-        0,  viewUp.y,   viewRight.y,  pivotPoint.y,
-        0,  viewUp.z,   viewRight.z,  pivotPoint.z,
-        0,  0,          0,            1
+        look.x,   viewRight.x,  viewUp.x,  0,
+        look.y,   viewRight.y,  viewUp.y,  0,
+        look.z,   viewRight.z,  viewUp.z,  0,
+        0,        0,            0,         1
       );
-
-      t2Matrix.set(
-        1,  0,          0,            -pivotPoint.x,
-        0,  1,          0,            -pivotPoint.y,
-        0,  0,          1,            -pivotPoint.z,
-        0,  0,          0,            1
-      );
-
-      tMatrix.multiply(t2Matrix);
 
       bone.rotation.setFromRotationMatrix(tMatrix);
-      // bone.applyMatrix(tMatrix);
     });
   }
 

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -34,10 +34,10 @@ class WorldHandler extends EventEmitter {
     this.player.on('map:change', this.changeMap);
     this.player.on('position:change', this.changePosition);
 
-    this.billboards = [];
+    this.billboardedM2s = [];
 
     // Darkshire (Eastern Kingdoms)
-    this.player.worldport(0, -10559, -1189, 28);
+    // this.player.worldport(0, -10559, -1189, 28);
 
     // Booty Bay (Eastern Kingdoms)
     // this.player.worldport(0, -14354, 518, 22);
@@ -142,10 +142,8 @@ class WorldHandler extends EventEmitter {
     this.renderAtCoords(player.position.x, player.position.y);
   }
 
-  addBillboards(newBillboards) {
-    if (newBillboards.length > 0) {
-      this.billboards = this.billboards.concat(newBillboards);
-    }
+  addBillboardedM2(m2) {
+    this.billboardedM2s.push(m2);
   }
 
   animate(camera) {
@@ -159,38 +157,11 @@ class WorldHandler extends EventEmitter {
 
   animateModels(camera, cameraRotated) {
     if (cameraRotated) {
-      this.animateBillboards(camera);
+      this.billboardedM2s.forEach((m2) => {
+        m2.applyBillboards(camera);
+      });
     }
   }
-
-  animateBillboards(camera) {
-    this.billboards.forEach((billboard) => {
-      const mesh = billboard[0];
-      const boneIndex = billboard[1];
-
-      const skeleton = mesh.skeleton;
-      const bone = skeleton.bones[boneIndex];
-
-      const mvMatrix = mesh.modelViewMatrix.elements;
-      const viewRight = new THREE.Vector3(mvMatrix[0], mvMatrix[4], mvMatrix[8]);
-      const viewUp = new THREE.Vector3(mvMatrix[1], mvMatrix[5], mvMatrix[9]);
-      const look = camera.getWorldDirection();
-
-      viewRight.multiplyScalar(-1);
-
-      const tMatrix = new THREE.Matrix4();
-
-      tMatrix.set(
-        look.x,   viewRight.x,  viewUp.x,  0,
-        look.y,   viewRight.y,  viewUp.y,  0,
-        look.z,   viewRight.z,  viewUp.z,  0,
-        0,        0,            0,         1
-      );
-
-      bone.rotation.setFromRotationMatrix(tMatrix);
-    });
-  }
-
 }
 
 export default WorldHandler;

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -12,6 +12,8 @@ class WorldHandler extends EventEmitter {
 
     this.scene = new THREE.Scene();
 
+    this.prevCameraRotation = null;
+
     // TODO: Use this handler for all entities, not just the player
     this.player.on('change:model', (oldModel, newModel) => {
       if (oldModel) {
@@ -95,12 +97,19 @@ class WorldHandler extends EventEmitter {
     }
   }
 
-  animate() {
-    this.animateModels();
+  animate(camera) {
+    const cameraRotated = this.prevCameraRotation === null ||
+      !this.prevCameraRotation.equals(camera.quaternion);
+
+    this.animateModels(cameraRotated);
+
+    this.prevCameraRotation = camera.quaternion.clone();
   }
 
-  animateModels() {
-    this.animateBillboards();
+  animateModels(cameraRotated) {
+    if (cameraRotated) {
+      this.animateBillboards();
+    }
   }
 
   animateBillboards() {

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -15,15 +15,6 @@ class WorldHandler extends EventEmitter {
 
     this.prevCameraRotation = null;
 
-    // TODO: Use this handler for all entities, not just the player
-    this.player.on('change:model', (oldModel, newModel) => {
-      if (oldModel) {
-        this.scene.remove(oldModel);
-      }
-
-      this.scene.add(newModel);
-    });
-
     this.changeMap = ::this.changeMap;
     this.changeModel = ::this.changeModel;
     this.changePosition = ::this.changePosition;

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -13,8 +13,6 @@ class WorldHandler extends EventEmitter {
     this.scene = new THREE.Scene();
     this.map = null;
 
-    this.prevCameraRotation = null;
-
     this.changeMap = ::this.changeMap;
     this.changeModel = ::this.changeModel;
     this.changePosition = ::this.changePosition;
@@ -24,8 +22,6 @@ class WorldHandler extends EventEmitter {
 
     this.player.on('map:change', this.changeMap);
     this.player.on('position:change', this.changePosition);
-
-    this.billboardedM2s = [];
 
     // Darkshire (Eastern Kingdoms)
     this.player.worldport(0, -10559, -1189, 28);
@@ -111,7 +107,6 @@ class WorldHandler extends EventEmitter {
         this.scene.remove(this.map);
       }
       this.map = map;
-      this.map.setWorld(this);
       this.scene.add(this.map);
       this.renderAtCoords(this.player.position.x, this.player.position.y);
     });
@@ -133,24 +128,9 @@ class WorldHandler extends EventEmitter {
     this.renderAtCoords(player.position.x, player.position.y);
   }
 
-  addBillboardedM2(m2) {
-    this.billboardedM2s.push(m2);
-  }
-
-  animate(camera) {
-    const cameraRotated = this.prevCameraRotation === null ||
-      !this.prevCameraRotation.equals(camera.quaternion);
-
-    this.animateModels(camera, cameraRotated);
-
-    this.prevCameraRotation = camera.quaternion.clone();
-  }
-
-  animateModels(camera, cameraRotated) {
-    if (cameraRotated) {
-      this.billboardedM2s.forEach((m2) => {
-        m2.applyBillboards(camera);
-      });
+  animate(camera, cameraRotated) {
+    if (this.map !== null) {
+      this.map.animate(camera, cameraRotated);
     }
   }
 }

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -23,15 +23,11 @@ class Map extends THREE.Group {
     this.wmos = {};
     this.doodads = {};
 
-    this.world = null;
+    this.billboardedM2s = [];
   }
 
   get internalName() {
     return this.data.internalName;
-  }
-
-  setWorld(world) {
-    this.world = world;
   }
 
   render(x, y) {
@@ -93,12 +89,28 @@ class Map extends THREE.Group {
 
           this.add(m2);
 
-          if (this.world !== null && m2.billboards.length > 0) {
-            this.world.addBillboardedM2(m2);
+          if (m2.billboards.length > 0) {
+            this.addBillboardedM2(m2);
           }
         });
       }
     });
+  }
+
+  addBillboardedM2(m2) {
+    this.billboardedM2s.push(m2);
+  }
+
+  animate(camera, cameraRotated) {
+    this.animateModels(camera, cameraRotated);
+  }
+
+  animateModels(camera, cameraRotated) {
+    if (cameraRotated) {
+      this.billboardedM2s.forEach((m2) => {
+        m2.applyBillboards(camera);
+      });
+    }
   }
 
   static load(id) {

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -22,10 +22,16 @@ class Map extends THREE.Group {
     // TODO: Track ADTs in some sort of fashion
     this.wmos = {};
     this.doodads = {};
+
+    this.world = null;
   }
 
   get internalName() {
     return this.data.internalName;
+  }
+
+  setWorld(world) {
+    this.world = world;
   }
 
   render(x, y) {
@@ -86,6 +92,10 @@ class Map extends THREE.Group {
           }
 
           this.add(m2);
+
+          if (this.world !== null) {
+            this.world.addBillboards(m2.billboards);
+          }
         });
       }
     });

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -93,8 +93,8 @@ class Map extends THREE.Group {
 
           this.add(m2);
 
-          if (this.world !== null) {
-            this.world.addBillboards(m2.billboards);
+          if (this.world !== null && m2.billboards.length > 0) {
+            this.world.addBillboardedM2(m2);
           }
         });
       }

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -120,11 +120,7 @@ class M2 extends THREE.Group {
 
       geometry.faceVertexUvs = [uvs];
 
-      let isBillboard = false;
-
-      if (indexedBones[submesh.rootBone].userData.isBillboard) {
-        isBillboard = true;
-      }
+      const isBillboard = indexedBones[submesh.rootBone].userData.isBillboard === true;
 
       const mesh = new Submesh(id, geometry, textureUnits, isBillboard);
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -21,12 +21,9 @@ class M2 extends THREE.Group {
 
     const bones = [];
     const rootBones = [];
-    const indexedBones = [];
 
-    this.data.bones.forEach((joint, index) => {
+    this.data.bones.forEach((joint) => {
       const bone = new THREE.Bone();
-
-      indexedBones[index] = bone;
 
       // M2 bone positioning seems to be inverted on X and Y
       const { pivotPoint } = joint;
@@ -120,7 +117,7 @@ class M2 extends THREE.Group {
 
       geometry.faceVertexUvs = [uvs];
 
-      const isBillboard = indexedBones[submesh.rootBone].userData.isBillboard === true;
+      const isBillboard = bones[submesh.rootBone].userData.isBillboard === true;
 
       const mesh = new Submesh(id, geometry, textureUnits, isBillboard);
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -35,8 +35,6 @@ class M2 extends THREE.Group {
 
       // Track billboarded bones
       if (joint.flags & 0x08) {
-        bone.userData.isBillboard = true;
-        bone.userData.pivotPoint = correctedPosition;
         this.billboards.push(bone);
       }
 
@@ -148,24 +146,11 @@ class M2 extends THREE.Group {
   }
 
   applyBillboard(camera, bone) {
-    const pivotPoint = bone.userData.pivotPoint;
+    const camPos = this.worldToLocal(camera.position.clone());
+    const camUp = camera.up.clone();
 
-    const tMatrix = new THREE.Matrix4().identity();
-
-    tMatrix.setPosition(pivotPoint);
-
-    const camPos = camera.position.clone();
-    const invMatrixWorld = new THREE.Matrix4().getInverse(this.matrixWorld);
-    camPos.applyMatrix4(invMatrixWorld);
-
-    const camUp = camera.up;
-
-    const modelForward = new THREE.Vector4(
-      camPos.x - pivotPoint.x,
-      camPos.y - pivotPoint.y,
-      camPos.z - pivotPoint.z,
-      0
-    ).normalize();
+    const modelForward = new THREE.Vector3(camPos.x, camPos.y, camPos.z);
+    modelForward.normalize();
 
     const modelRight = new THREE.Vector3();
     modelRight.crossVectors(camUp, modelForward);
@@ -184,9 +169,7 @@ class M2 extends THREE.Group {
       0,                0,              0,          1
     );
 
-    tMatrix.multiply(rotateMatrix);
-
-    bone.rotation.setFromRotationMatrix(tMatrix);
+    bone.rotation.setFromRotationMatrix(rotateMatrix);
   }
 
   static load(path) {

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -13,6 +13,7 @@ class M2 extends THREE.Group {
     this.path = path;
     this.data = data;
     this.skinData = skinData;
+    this.billboards = [];
 
     const sharedGeometry = new THREE.Geometry();
 
@@ -20,8 +21,14 @@ class M2 extends THREE.Group {
 
     const bones = [];
     const rootBones = [];
+    const billboardedBones = [];
 
-    this.data.bones.forEach((joint) => {
+    this.data.bones.forEach((joint, index) => {
+      // Track billboarded bones
+      if (joint.flags & 0x08) {
+        billboardedBones.push([index, joint.pivotPoint]);
+      }
+
       const bone = new THREE.Bone();
 
       const { pivotPoint } = joint;
@@ -120,6 +127,16 @@ class M2 extends THREE.Group {
       mesh.bind(this.skeleton);
 
       this.add(mesh);
+
+      // Preserve billboarded bones for animation in the WorldHandler.
+      if (billboardedBones.length > 0) {
+        billboardedBones.forEach((billboardedBone) => {
+          // Not really sure about appropriate way to determine if mesh is relevant
+          if (billboardedBone[0] === submesh.rootBone) {
+            this.billboards.push([mesh, billboardedBone[0], billboardedBone[1]]);
+          }
+        });
+      }
     });
   }
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -26,7 +26,7 @@ class M2 extends THREE.Group {
     this.data.bones.forEach((joint, index) => {
       // Track billboarded bones
       if (joint.flags & 0x08) {
-        billboardedBones.push([index, joint.pivotPoint]);
+        billboardedBones.push(index);
       }
 
       const bone = new THREE.Bone();
@@ -128,14 +128,10 @@ class M2 extends THREE.Group {
 
       this.add(mesh);
 
-      // Preserve billboarded bones for animation in the WorldHandler.
-      if (billboardedBones.length > 0) {
-        billboardedBones.forEach((billboardedBone) => {
-          // Not really sure about appropriate way to determine if mesh is relevant
-          if (billboardedBone[0] === submesh.rootBone) {
-            this.billboards.push([mesh, billboardedBone[0], billboardedBone[1]]);
-          }
-        });
+      // Preserve billboarded bones for animation in the WorldHandler. Not really sure about
+      // appropriate way to determine if mesh's bones are relevant.
+      if (billboardedBones.length > 0 && billboardedBones.indexOf(submesh.rootBone) !== -1) {
+        this.billboards.push([mesh, submesh.rootBone]);
       }
     });
   }

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -106,10 +106,10 @@ class Submesh extends THREE.SkinnedMesh {
         break;
 
       case 5:
-        this.material.blendSrc = THREE.SrcAlphaFactor;
-        this.material.blendDst = THREE.OneMinusSrcAlphaFactor;
-        this.material.blendSrcAlpha = THREE.SrcAlphaFactor;
-        this.material.blendDstAlpha = THREE.OneMinusSrcAlphaFactor;
+        this.material.blendSrc = THREE.DstColorFactor;
+        this.material.blendDst = THREE.ZeroFactor;
+        this.material.blendSrcAlpha = THREE.DstAlphaFactor;
+        this.material.blendDstAlpha = THREE.ZeroFactor;
         break;
 
       case 6:

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -99,6 +99,10 @@ class Submesh extends THREE.SkinnedMesh {
         break;
 
       case 4:
+        this.material.transparent = true;
+
+        this.material.side = THREE.DoubleSide;
+
         this.material.blendSrc = THREE.SrcAlphaFactor;
         this.material.blendDst = THREE.OneFactor;
         this.material.blendSrcAlpha = THREE.SrcAlphaFactor;


### PR DESCRIPTION
Bones that have the billboard flag set (0x08) now face the camera and update to continue facing the camera when the camera rotates. This is done with a few hooks in to the animate() handler in ```game\index.jsx``` -- not sure if that's the best approach, but it hopefully does the trick for now.

In addition to the billboard support, I've fixed up some issues with render flags. In particular: any submesh that is billboarded now has two sided rendering on the material to avoid vanishing textures when moving / rotating about the world; alpha transparencies should now apply to textures in any billboarded submesh; and the options for one of the blending modes have been corrected to proper values.

A side note about transparency flagging for materials: at some point, this is going to have to be done differently. As we've learned before, we can't just enable transparency on all materials with blending modes >= 1-- that makes the normally opaque body on the Northrend Penguin model turn semi-transparent. WowModelViewer appears to base its choice for flagging transparency on whether or not the blending mode is >= 1 AND the opacity is set to a non-zero value on the transparency lookup for the textureUnit. That might be a better approach once we have integrated transparency lookups.