### PR TITLE
Initial M2 animation support and improved M2 texture handling

### DIFF
--- a/src/components/game/index.jsx
+++ b/src/components/game/index.jsx
@@ -26,6 +26,9 @@ class GameScreen extends React.Component {
 
     this.renderer = null;
     this.requestID = null;
+
+    // For some reason, we can't use the clock from controls here.
+    this.clock = new THREE.Clock();
   }
 
   componentDidMount() {
@@ -74,7 +77,7 @@ class GameScreen extends React.Component {
     const cameraRotated = this.prevCameraRotation === null ||
       !this.prevCameraRotation.equals(this.camera.quaternion);
 
-    session.world.animate(this.camera, cameraRotated);
+    session.world.animate(this.clock.getDelta(), this.camera, cameraRotated);
 
     this.renderer.render(session.world.scene, this.camera);
     this.requestID = requestAnimationFrame(this.animate);

--- a/src/lib/game/unit.js
+++ b/src/lib/game/unit.js
@@ -69,7 +69,15 @@ class Unit extends Entity {
     if (this._model) {
       this.view.remove(this._model);
     }
+
     this.view.add(m2);
+
+    // Auto-play animation index 0 in unit model, if present
+    // TODO: Properly manage unit animations
+    if (m2.isAnimated && m2.animations.length > 0) {
+      m2.animations.play(0);
+    }
+
     this.emit('model:change', this, this._model, m2);
     this._model = m2;
   }

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -121,6 +121,10 @@ class WorldHandler extends EventEmitter {
     if (newModel) {
       newModel.skeletonHelper = new THREE.SkeletonHelper(newModel);
       this.scene.add(newModel.skeletonHelper);
+
+      if (newModel.isAnimated && this.map !== null) {
+        this.map.addAnimatedM2(newModel);
+      }
     }
   }
 
@@ -128,9 +132,9 @@ class WorldHandler extends EventEmitter {
     this.renderAtCoords(player.position.x, player.position.y);
   }
 
-  animate(camera, cameraRotated) {
+  animate(delta, camera, cameraRotated) {
     if (this.map !== null) {
-      this.map.animate(camera, cameraRotated);
+      this.map.animate(delta, camera, cameraRotated);
     }
   }
 }

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -121,10 +121,6 @@ class WorldHandler extends EventEmitter {
     if (newModel) {
       newModel.skeletonHelper = new THREE.SkeletonHelper(newModel);
       this.scene.add(newModel.skeletonHelper);
-
-      if (newModel.isAnimated && this.map !== null) {
-        this.map.addAnimatedM2(newModel);
-      }
     }
   }
 
@@ -133,9 +129,33 @@ class WorldHandler extends EventEmitter {
   }
 
   animate(delta, camera, cameraRotated) {
+    this.animateEntities(delta, camera, cameraRotated);
+
     if (this.map !== null) {
       this.map.animate(delta, camera, cameraRotated);
     }
+  }
+
+  animateEntities(delta, camera, cameraRotated) {
+    this.entities.forEach((entity) => {
+      const { model } = entity;
+
+      if (model === null || !model.isAnimated) {
+        return;
+      }
+
+      if (model.animations.length > 0) {
+        model.animations.update(delta);
+      }
+
+      if (cameraRotated && model.billboards.length > 0) {
+        model.applyBillboards(camera);
+      }
+
+      if (model.skeletonHelper) {
+        model.skeletonHelper.update();
+      }
+    });
   }
 }
 

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -23,7 +23,7 @@ class Map extends THREE.Group {
     this.wmos = {};
     this.doodads = {};
 
-    this.billboardedM2s = [];
+    this.animatedM2s = [];
   }
 
   get internalName() {
@@ -89,28 +89,38 @@ class Map extends THREE.Group {
 
           this.add(m2);
 
-          if (m2.billboards.length > 0) {
-            this.addBillboardedM2(m2);
+          if (m2.isAnimated) {
+            this.addAnimatedM2(m2);
           }
         });
       }
     });
   }
 
-  addBillboardedM2(m2) {
-    this.billboardedM2s.push(m2);
+  addAnimatedM2(m2) {
+    this.animatedM2s.push(m2);
   }
 
-  animate(camera, cameraRotated) {
-    this.animateModels(camera, cameraRotated);
+  animate(delta, camera, cameraRotated) {
+    this.animateModels(delta, camera, cameraRotated);
   }
 
-  animateModels(camera, cameraRotated) {
-    if (cameraRotated) {
-      this.billboardedM2s.forEach((m2) => {
+  animateModels(delta, camera, cameraRotated) {
+    this.animatedM2s.forEach((m2) => {
+      // TODO: Manage which animations play and when.
+      if (m2.animations.length > 0) {
+        m2.animations[0].update(delta);
+      }
+
+      if (cameraRotated) {
         m2.applyBillboards(camera);
-      });
-    }
+      }
+
+      // If present, ensure the skeleton helper animates with the model.
+      if (m2.skeletonHelper) {
+        m2.skeletonHelper.update();
+      }
+    });
   }
 
   static load(id) {

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -98,6 +98,9 @@ class Map extends THREE.Group {
   }
 
   addAnimatedM2(m2) {
+    // TODO: Manage which animations play and when.
+    m2.animations.play(0);
+
     this.animatedM2s.push(m2);
   }
 
@@ -107,9 +110,8 @@ class Map extends THREE.Group {
 
   animateModels(delta, camera, cameraRotated) {
     this.animatedM2s.forEach((m2) => {
-      // TODO: Manage which animations play and when.
       if (m2.animations.length > 0) {
-        m2.animations[0].update(delta);
+        m2.animations.update(delta);
       }
 
       if (cameraRotated) {

--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -3,6 +3,8 @@ import THREE from 'three';
 class AnimationManager {
 
   constructor(root, animationDefs) {
+    this.animationDefs = animationDefs;
+
     this.clips = [];
     this.activeActions = {};
 
@@ -11,7 +13,7 @@ class AnimationManager {
     // M2 animations are keyframed in milliseconds.
     this.mixer.timeScale = 1000.0;
 
-    this.registerClips(animationDefs);
+    this.registerClips(this.animationDefs);
 
     this.length = this.clips.length;
   }
@@ -56,6 +58,13 @@ class AnimationManager {
     const animationBlock = opts.animationBlock;
 
     animationBlock.tracks.forEach((trackDef, animationIndex) => {
+      const animationDef = this.animationDefs[animationIndex];
+
+      // Avoid creating tracks for external .anim animations.
+      if ((animationDef.flags & 0x130) === 0) {
+        return;
+      }
+
       // Avoid attempting to create empty tracks.
       if (trackDef.keyframes.length === 0) {
         return;

--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -7,6 +7,8 @@ class AnimationManager {
     this.activeActions = {};
 
     this.mixer = new THREE.AnimationMixer(root);
+
+    // M2 animations are keyframed in milliseconds.
     this.mixer.timeScale = 1000.0;
 
     this.registerClips(animationDefs);
@@ -77,24 +79,6 @@ class AnimationManager {
 
       clip.trim();
       clip.optimize();
-    });
-  }
-
-  registerAnimations() {
-    this.animationClips.forEach((clip) => {
-      const animationMixer = new THREE.AnimationMixer(this);
-
-      // M2 animations are keyframed in milliseconds.
-      animationMixer.timeScale = 1000.0;
-
-      clip.trim();
-      clip.optimize();
-
-      const action = new THREE.AnimationAction(clip);
-
-      animationMixer.addAction(action);
-
-      this.animations.push(animationMixer);
     });
   }
 

--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -1,0 +1,103 @@
+import THREE from 'three';
+
+class AnimationManager {
+
+  constructor(root, animationDefs) {
+    this.clips = [];
+    this.activeActions = {};
+
+    this.mixer = new THREE.AnimationMixer(root);
+    this.mixer.timeScale = 1000.0;
+
+    this.registerClips(animationDefs);
+
+    this.length = this.clips.length;
+  }
+
+  update(delta) {
+    this.mixer.update(delta);
+  }
+
+  play(animationIndex) {
+    // The animation is already playing.
+    if (typeof this.activeActions[animationIndex] !== 'undefined') {
+      return;
+    }
+
+    const clip = this.clips[animationIndex];
+
+    const action = new THREE.AnimationAction(clip);
+
+    this.mixer.play(action);
+    this.activeActions[animationIndex] = action;
+  }
+
+  stop(animationIndex) {
+    // The animation isn't currently playing.
+    if (typeof this.activeActions[animationIndex] === 'undefined') {
+      return;
+    }
+
+    this.mixer.removeAction(this.activeActions[animationIndex]);
+    delete this.activeActions[animationIndex];
+  }
+
+  registerClips(animationDefs) {
+    animationDefs.forEach((animationDef, index) => {
+      const clip = new THREE.AnimationClip('animation-' + index, animationDef.length, []);
+      this.clips[index] = clip;
+    });
+  }
+
+  registerTrack(opts) {
+    const trackName = opts.target.uuid + '.' + opts.property;
+    const animationBlock = opts.animationBlock;
+
+    animationBlock.tracks.forEach((trackDef, animationIndex) => {
+      // Avoid attempting to create empty tracks.
+      if (trackDef.keyframes.length === 0) {
+        return;
+      }
+
+      const keyframes = [];
+
+      trackDef.keyframes.forEach((keyframeDef) => {
+        const keyframe = {
+          time: keyframeDef.time,
+          value: opts.valueTransform(keyframeDef.value)
+        };
+
+        keyframes.push(keyframe);
+      });
+
+      const clip = this.clips[animationIndex];
+      const track = new THREE[opts.trackType](trackName, keyframes);
+
+      clip.tracks.push(track);
+
+      clip.trim();
+      clip.optimize();
+    });
+  }
+
+  registerAnimations() {
+    this.animationClips.forEach((clip) => {
+      const animationMixer = new THREE.AnimationMixer(this);
+
+      // M2 animations are keyframed in milliseconds.
+      animationMixer.timeScale = 1000.0;
+
+      clip.trim();
+      clip.optimize();
+
+      const action = new THREE.AnimationAction(clip);
+
+      animationMixer.addAction(action);
+
+      this.animations.push(animationMixer);
+    });
+  }
+
+}
+
+export default AnimationManager;

--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -53,6 +53,17 @@ class AnimationManager {
     });
   }
 
+  unregisterTrack(trackName) {
+    this.clips.forEach((clip) => {
+      clip.tracks = clip.tracks.filter((track) => {
+        return track.name !== trackName;
+      });
+
+      clip.trim();
+      clip.optimize();
+    });
+  }
+
   registerTrack(opts) {
     const trackName = opts.target.uuid + '.' + opts.property;
     const animationBlock = opts.animationBlock;
@@ -89,6 +100,8 @@ class AnimationManager {
       clip.trim();
       clip.optimize();
     });
+
+    return trackName;
   }
 
 }

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -200,14 +200,14 @@ class M2 extends THREE.Group {
       });
 
       const submeshOpts = {
+        index: id,
         geometry: submeshGeometry,
-        skeleton: this.skeleton,
         rootBones: rootBones,
         textureUnits: submeshTextureUnits,
         isBillboard: isBillboard
       };
 
-      const mesh = new Submesh(id, submeshOpts);
+      const mesh = new Submesh(this, submeshOpts);
 
       this.add(mesh);
     });


### PR DESCRIPTION
* When M2s are loaded, their bone animations (translation, rotation, and scaling) are also loaded using AnimationManager, a simple wrapper around the three.js animation system. Additionally, transparency animations on M2 submesh textures are registered with the parent M2's AnimationManager.

* The first-by-index animation in each loaded unit and doodad M2 is auto-played on infinite loop.

* Added use of texture lookup table indirection when selecting textures for M2 skins' texture units. This fixes textures on several M2s, including the gryphon roosts and wells in Darkshire.

* Multiple texture units are applied in order using aligned child meshes on the submesh group. A more appropriate solution would likely involve blending multiple textures using a shader.

* Added missing blending property change to materials in submeshes. To get three.js to honor customized blendSrc, blendDst, and etc properties, a material's blending property needs to be set to THREE.CustomBlending. Blending modes are now honored, and several models look much better.

* Removed several unneeded workarounds for render flags / blending mode application. Using separate meshes per texture unit eliminated the cause of the issues that were worked around: an inappropriate holdover of render flags and the blending mode between separate texture units.

* Enabled no-depth-write flag for texture units.

* Hooked up simple buffer geometry for submeshes. Proper use of buffer geometry would probably improve performance and load times.