### PR TITLE
Pipeline: Fix resource leak

### DIFF
--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -67,14 +67,8 @@ class M2 extends THREE.Group {
           trackType: 'VectorKeyframeTrack',
 
           valueTransform: function(value) {
-            const translatedBone = bone.clone();
-
-            // Same inverted X and Y values as the pivotPoint above.
-            translatedBone.translateX(-value.x);
-            translatedBone.translateY(-value.y);
-            translatedBone.translateZ(value.z);
-
-            return translatedBone.position;
+            const translation = new THREE.Vector3(-value.x, -value.y, value.z);
+            return bone.position.clone().add(translation);
           }
         });
       }

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -27,7 +27,9 @@ class M2 extends THREE.Group {
     const bones = [];
     const rootBones = [];
 
-    this.data.bones.forEach((joint) => {
+    for (let boneIndex = 0, len = this.data.bones.length; boneIndex < len; ++boneIndex) {
+      const joint = this.data.bones[boneIndex];
+
       const bone = new THREE.Bone();
 
       // M2 bone positioning seems to be inverted on X and Y
@@ -104,14 +106,17 @@ class M2 extends THREE.Group {
           }
         });
       }
-    });
+    }
 
     this.skeleton = new THREE.Skeleton(bones);
 
     const vertices = data.vertices;
 
-    vertices.forEach(function(vertex) {
+    for (let vertexIndex = 0, len = vertices.length; vertexIndex < len; ++vertexIndex) {
+      const vertex = vertices[vertexIndex];
+
       const { position } = vertex;
+
       sharedGeometry.vertices.push(
         // Provided as (X, Z, -Y)
         new THREE.Vector3(position[0], position[2], -position[1])
@@ -124,7 +129,7 @@ class M2 extends THREE.Group {
       sharedGeometry.skinWeights.push(
         new THREE.Vector4(...vertex.boneWeights)
       );
-    });
+    }
 
     // Mirror geometry over X and Y axes and rotate
     const matrix = new THREE.Matrix4();
@@ -137,7 +142,9 @@ class M2 extends THREE.Group {
     const { indices, textureUnits, triangles } = skinData;
 
     // TODO: Look up colors, render flags and what not
-    textureUnits.forEach(function(textureUnit) {
+    for (let tuIndex = 0, len = textureUnits.length; tuIndex < len; ++tuIndex) {
+      const textureUnit = textureUnits[tuIndex];
+
       const textureLookup = textureLookups[textureUnit.textureIndex];
       const texture = textures[textureLookup];
       textureUnit.texture = texture;
@@ -154,9 +161,13 @@ class M2 extends THREE.Group {
         const color = colors[textureUnit.colorIndex];
         textureUnit.color = color;
       }
-    });
+    }
 
-    this.skinData.submeshes.forEach((submesh, id) => {
+    const { submeshes } = this.skinData;
+
+    for (let submeshIndex = 0, subLen = submeshes.length; submeshIndex < subLen; ++submeshIndex) {
+      const submesh = submeshes[submeshIndex];
+
       const geometry = sharedGeometry.clone();
 
       // TODO: Figure out why this isn't cloned by the line above
@@ -178,10 +189,12 @@ class M2 extends THREE.Group {
         geometry.faces.push(face);
 
         uvs[faceIndex] = [];
-        vindices.forEach(function(index) {
+        for (let vinIndex = 0, vinLen = vindices.length; vinIndex < vinLen; ++vinIndex) {
+          const index = vindices[vinIndex];
+
           const { textureCoords } = vertices[index];
           uvs[faceIndex].push(new THREE.Vector2(textureCoords[0], textureCoords[1]));
-        });
+        }
       }
 
       geometry.faceVertexUvs = [uvs];
@@ -193,14 +206,17 @@ class M2 extends THREE.Group {
       // Extract texture units associated with this particular submesh, since not all texture units
       // apply to all submeshes.
       const submeshTextureUnits = [];
-      textureUnits.forEach((textureUnit) => {
-        if (textureUnit.submeshIndex === id) {
+
+      for (let tuIndex = 0, tuLen = textureUnits.length; tuIndex < tuLen; ++tuIndex) {
+        const textureUnit = textureUnits[tuIndex];
+
+        if (textureUnit.submeshIndex === submeshIndex) {
           submeshTextureUnits.push(textureUnit);
         }
-      });
+      }
 
       const submeshOpts = {
-        index: id,
+        index: submeshIndex,
         geometry: submeshGeometry,
         rootBones: rootBones,
         textureUnits: submeshTextureUnits,
@@ -210,13 +226,14 @@ class M2 extends THREE.Group {
       const mesh = new Submesh(this, submeshOpts);
 
       this.add(mesh);
-    });
+    }
   }
 
   applyBillboards(camera) {
-    this.billboards.forEach((bone) => {
+    for (let i = 0, len = this.billboards.length; i < len; ++i) {
+      const bone = this.billboards[i];
       this.applyBillboard(camera, bone);
-    });
+    }
   }
 
   applyBillboard(camera, bone) {
@@ -254,9 +271,10 @@ class M2 extends THREE.Group {
   }
 
   set displayInfo(displayInfo) {
-    this.children.forEach(function(submesh) {
+    for (let i = 0, len = this.children.length; i < len; ++i) {
+      const submesh = this.children[i];
       submesh.displayInfo = displayInfo;
-    });
+    }
   }
 
   clone() {

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -32,7 +32,9 @@ class Submesh extends THREE.Group {
     this.clearTextureMeshes();
 
     // Create meshes for each texture unit and add to the group.
-    this.textureUnits.forEach((textureUnit) => {
+    for (let tuIndex = 0, tuLen = this.textureUnits.length; tuIndex < tuLen; ++tuIndex) {
+      const textureUnit = this.textureUnits[tuIndex];
+
       const material = this.createMaterial(textureUnit);
       const textureMesh = new THREE.SkinnedMesh(this.geometry, material);
 
@@ -46,7 +48,7 @@ class Submesh extends THREE.Group {
       this.add(textureMesh);
 
       this.registerTextureAnimations(textureMesh, textureUnit);
-    });
+    }
   }
 
   clearTextureAnimations() {

--- a/src/lib/server/pipeline/index.js
+++ b/src/lib/server/pipeline/index.js
@@ -33,6 +33,9 @@ class Pipeline {
     req.resource = this.archive.files.get(path);
     if (req.resource) {
       next();
+
+      // Ensure file is closed in StormLib.
+      req.resource.close();
     } else {
       const err = new Error('resource not found');
       err.status = 404;


### PR DESCRIPTION
After the pipeline server responds to a request, there's no call to ```close()``` on ```req.resource```, which is a ```File``` from ```blizzardry/src/lib/mpq/file.js```.

I believe ```close()``` is necessary to get StormLib to free up its handle on the file loaded out of the MPQ.

Adding ```close()``` appears to keep the pipeline server from bloating into the multi-GB range for memory usage after extended sessions in Wowser. With the fix, I've been able to observe memory usage going down after a period of time--which never seemed to happen before.