### PR TITLE
Pipeline: Fix resource leak

### DIFF
--- a/src/lib/server/pipeline/index.js
+++ b/src/lib/server/pipeline/index.js
@@ -33,6 +33,9 @@ class Pipeline {
     req.resource = this.archive.files.get(path);
     if (req.resource) {
       next();
+
+      // Ensure file is closed in StormLib.
+      req.resource.close();
     } else {
       const err = new Error('resource not found');
       err.status = 404;


### PR DESCRIPTION
After the pipeline server responds to a request, there's no call to ```close()``` on ```req.resource```, which is a ```File``` from ```blizzardry/src/lib/mpq/file.js```.

I believe ```close()``` is necessary to get StormLib to free up its handle on the file loaded out of the MPQ.