### PR TITLE
M2: Refactor

### DIFF
--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -148,7 +148,7 @@ class WorldMap extends THREE.Group {
 
       // Auto-play animation index 0 in doodad, if animations are present
       // TODO: Properly manage doodad animations
-      if (m2.isAnimated && m2.animations.length > 0) {
+      if (m2.animated && m2.animations.length > 0) {
         m2.animations.play(0);
       }
     }));
@@ -188,7 +188,7 @@ class WorldMap extends THREE.Group {
 
   animateDoodads(delta, camera, cameraRotated) {
     this.doodads.forEach((doodad) => {
-      if (!doodad.isAnimated) {
+      if (!doodad.animated) {
         return;
       }
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -23,7 +23,7 @@ class M2 extends THREE.Group {
     // Instanceable M2s can share geometry and texture units.
     this.canInstance = data.canInstance;
 
-    this.isAnimated = data.isAnimated;
+    this.animated = data.animated;
     this.animations = new AnimationManager(this, data.animations);
     this.billboards = [];
 
@@ -91,18 +91,18 @@ class M2 extends THREE.Group {
       }
 
       // Enable skinning support on this M2 if we have bone animations.
-      if (boneDef.isAnimated) {
+      if (boneDef.animated) {
         this.useSkinning = true;
       }
 
       // Flag billboarded bones
-      if (boneDef.isBillboarded) {
-        bone.userData.isBillboarded = true;
+      if (boneDef.billboarded) {
+        bone.userData.billboarded = true;
         billboards.push(bone);
       }
 
       // Bone translation animation block
-      if (boneDef.translation.isAnimated) {
+      if (boneDef.translation.animated) {
         this.animations.registerTrack({
           target: bone,
           property: 'position',
@@ -117,7 +117,7 @@ class M2 extends THREE.Group {
       }
 
       // Bone rotation animation block
-      if (boneDef.rotation.isAnimated) {
+      if (boneDef.rotation.animated) {
         this.animations.registerTrack({
           target: bone,
           property: 'quaternion',
@@ -131,7 +131,7 @@ class M2 extends THREE.Group {
       }
 
       // Bone scaling animation block
-      if (boneDef.scaling.isAnimated) {
+      if (boneDef.scaling.animated) {
         this.animations.registerTrack({
           target: bone,
           property: 'scale',

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -9,10 +9,8 @@ class M2 extends THREE.Group {
 
   static cache = {};
 
-  constructor(path, data, skinData, instanceOpts) {
+  constructor(path, data, skinData, instance = null) {
     super();
-
-    const instance = instanceOpts || null;
 
     this.name = path.split('\\').slice(-1).pop();
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -181,9 +181,9 @@ class M2 extends THREE.Group {
         opCount: textureUnit.opCount,
         renderFlags: null,
         blendingMode: null,
+        color: null,
         textures: [],
-        transparency: null,
-        color: null
+        transparencies: []
       };
 
       // Shader ID (needs to be unmasked to get actual shader ID)
@@ -194,23 +194,25 @@ class M2 extends THREE.Group {
       materialDef.renderFlags = renderFlags[renderFlagsIndex].flags;
       materialDef.blendingMode = renderFlags[renderFlagsIndex].blendingMode;
 
-      // Color animation block
+      // Vertex color animation block
       if (textureUnit.colorIndex > -1) {
         materialDef.color = colors[textureUnit.colorIndex];
       }
 
-      // Transparency animation block
-      if (textureUnit.transparencyIndex > -1) {
-        const transparencyLookup = textureUnit.transparencyIndex;
-        const transparencyIndex = transparencyLookups[transparencyLookup];
-        materialDef.transparency = transparencies[transparencyIndex];
-      }
-
       for (let opIndex = 0; opIndex < opCount; ++opIndex) {
+        // Texture
         const textureLookup = textureUnit.textureIndex + opIndex;
         const textureIndex = textureLookups[textureLookup];
         const texture = textures[textureIndex];
         materialDef.textures[opIndex] = texture;
+
+        // Texture transparency animation block
+        const transparencyLookup = textureUnit.transparencyIndex + opIndex;
+        const transparencyIndex = transparencyLookups[transparencyLookup];
+        const transparency = transparencies[transparencyIndex];
+        if (transparency) {
+          materialDef.transparencies[opIndex] = transparency;
+        }
       }
 
       // Observe the M2's skinning flag in the M2Material.

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -33,8 +33,6 @@ class M2 extends THREE.Group {
     // three.js.
     this.useSkinning = false;
 
-    this.material = null;
-
     this.mesh = null;
     this.submeshes = [];
     this.parts = new Map();

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -9,10 +9,10 @@ class M2 extends THREE.Group {
 
   static cache = {};
 
-  constructor(path, data, skinData, sharedOpts) {
+  constructor(path, data, skinData, instanceOpts) {
     super();
 
-    const shared = sharedOpts || null;
+    const instance = instanceOpts || null;
 
     this.name = path.split('\\').slice(-1).pop();
 
@@ -20,7 +20,9 @@ class M2 extends THREE.Group {
     this.data = data;
     this.skinData = skinData;
 
-    this.isInstanced = data.isInstanced;
+    // Instanceable M2s can share geometry and texture units.
+    this.canInstance = data.canInstance;
+
     this.isAnimated = data.isAnimated;
     this.animations = new AnimationManager(this, data.animations);
     this.billboards = [];
@@ -46,11 +48,11 @@ class M2 extends THREE.Group {
 
     this.createSkeleton(data.bones);
 
-    // Non-instanced M2s can share geometries and texture units
-    if (shared) {
-      this.textureUnits = shared.textureUnits;
-      this.geometry = shared.geometry;
-      this.submeshGeometries = shared.submeshGeometries;
+    // Instanced M2s can share geometries and texture units.
+    if (instance) {
+      this.textureUnits = instance.textureUnits;
+      this.geometry = instance.geometry;
+      this.submeshGeometries = instance.submeshGeometries;
     } else {
       this.createTextureUnits(data, skinData);
       this.createGeometry(data.vertices);
@@ -410,17 +412,17 @@ class M2 extends THREE.Group {
   }
 
   clone() {
-    let shared = {};
+    let instance = {};
 
-    if (!this.isInstanced) {
-      shared.geometry = this.geometry;
-      shared.submeshGeometries = this.submeshGeometries;
-      shared.textureUnits = this.textureUnits;
+    if (this.canInstance) {
+      instance.geometry = this.geometry;
+      instance.submeshGeometries = this.submeshGeometries;
+      instance.textureUnits = this.textureUnits;
     } else {
-      shared = null;
+      instance = null;
     }
 
-    return new this.constructor(this.path, this.data, this.skinData, shared);
+    return new this.constructor(this.path, this.data, this.skinData, instance);
   }
 
   static load(path) {

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -323,7 +323,6 @@ class M2 extends THREE.Group {
         indices[triangles[i + 2]]
       ];
 
-      // TODO: Handle normal vectors.
       const face = new THREE.Face3(vindices[0], vindices[1], vindices[2]);
 
       geometry.faces.push(face);
@@ -332,9 +331,11 @@ class M2 extends THREE.Group {
       for (let vinIndex = 0, vinLen = vindices.length; vinIndex < vinLen; ++vinIndex) {
         const index = vindices[vinIndex];
 
-        const { textureCoords } = vertices[index];
+        const { textureCoords, normal } = vertices[index];
 
         uvs[faceIndex].push(new THREE.Vector2(textureCoords[0], textureCoords[1]));
+
+        face.vertexNormals.push(new THREE.Vector3(normal[0], normal[1], normal[2]));
       }
     }
 

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -7,7 +7,11 @@ import fragmentShader from './shader.frag';
 class M2Material extends THREE.ShaderMaterial {
 
   constructor(def) {
-    super({ skinning: true });
+    if (def.useSkinning) {
+      super({ skinning: true });
+    } else {
+      super({ skinning: false });
+    }
 
     const vertexShaderMode = this.vertexShaderModeFromID(def.shaderID, def.opCount);
     const fragmentShaderMode = this.fragmentShaderModeFromID(def.shaderID, def.opCount);

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -1,0 +1,243 @@
+import THREE from 'three';
+
+import TextureLoader from '../../texture-loader';
+import vertexShader from './shader.vert';
+import fragmentShader from './shader.frag';
+
+class M2Material extends THREE.ShaderMaterial {
+
+  constructor(def) {
+    super({ skinning: true });
+
+    const vertexShaderMode = this.vertexShaderModeFromID(def.shaderID, def.opCount);
+    const fragmentShaderMode = this.fragmentShaderModeFromID(def.shaderID, def.opCount);
+
+    this.uniforms = {
+      textureCount: { type: 'i', value: 0 },
+      textures: { type: 'tv', value: [] },
+
+      vertexShaderMode: { type: 'i', value: vertexShaderMode },
+      fragmentShaderMode: { type: 'i', value: fragmentShaderMode },
+
+      billboarded: { type: 'f', value: 0.0 },
+
+      // Managed by light manager
+      lightModifier: { type: 'f', value: '1.0' },
+      ambientLight: { type: 'c', value: new THREE.Color(0.5, 0.5, 0.5) },
+      diffuseLight: { type: 'c', value: new THREE.Color(0.25, 0.5, 1.0) },
+
+      // Managed by light manager
+      fogModifier: { type: 'f', value: '1.0' },
+      fogColor: { type: 'c', value: new THREE.Color(0.25, 0.5, 1.0) },
+      fogStart: { type: 'f', value: 5.0 },
+      fogEnd: { type: 'f', value: 400.0 }
+    };
+
+    this.vertexShader = vertexShader;
+    this.fragmentShader = fragmentShader;
+
+    this.applyRenderFlags(def.renderFlags);
+    this.applyBlendingMode(def.blendingMode);
+
+    // Shader ID is a masked int that determines mode for vertex and fragment shader.
+    this.shaderID = def.shaderID;
+
+    // Loaded by calling updateSkinTextures()
+    this.skins = {};
+    this.skins.skin1 = null;
+    this.skins.skin2 = null;
+    this.skins.skin3 = null;
+
+    this.textureDefs = def.textures;
+    this.loadTextures();
+  }
+
+  // TODO: Fully expand these lookups.
+  vertexShaderModeFromID(shaderID, opCount) {
+    if (opCount === 1) {
+      return 0;
+    }
+
+    if (shaderID === 0) {
+      return 1;
+    }
+
+    return -1;
+  }
+
+  // TODO: Fully expand these lookups.
+  fragmentShaderModeFromID(shaderID, opCount) {
+    if (opCount === 1) {
+      // fragCombinersOpaque
+      return 0;
+    }
+
+    if (shaderID === 0) {
+      // fragCombinersOpaqueOpaque
+      return 1;
+    }
+
+    // Unknown / unhandled
+    return -1;
+  }
+
+  enableBillboarding() {
+    // TODO: Make billboarding happen in the vertex shader.
+    this.uniforms.billboarded = { type: 'f', value: '1.0' };
+
+    // TODO: Shouldn't this be FrontSide? Billboarding logic currently seems to flips the mesh
+    // backward.
+    this.side = THREE.BackSide;
+  }
+
+  applyRenderFlags(renderFlags) {
+    // Flag 0x01 (unlit)
+    if (renderFlags & 0x01) {
+      this.uniforms.lightModifier = { type: 'f', value: '0.0' };
+    }
+
+    // Flag 0x02 (unfogged)
+    if (renderFlags & 0x02) {
+      this.uniforms.fogModifier = { type: 'f', value: '0.0' };
+    }
+
+    // Flag 0x04 (no backface culling)
+    if (renderFlags & 0x04) {
+      this.side = THREE.DoubleSide;
+      this.transparent = true;
+    }
+
+    // Flag 0x10 (no z-buffer write)
+    if (renderFlags & 0x10) {
+      this.depthWrite = false;
+    }
+  }
+
+  applyBlendingMode(blendingMode) {
+    if (blendingMode === 1) {
+      this.uniforms.alphaKey = { type: 'f', value: 1.0 };
+    } else {
+      this.uniforms.alphaKey = { type: 'f', value: 0.0 };
+    }
+
+    if (blendingMode >= 1) {
+      this.transparent = true;
+      this.blending = THREE.CustomBlending;
+    }
+
+    switch (blendingMode) {
+      case 0:
+        this.blending = THREE.NoBlending;
+        this.blendSrc = THREE.OneFactor;
+        this.blendDst = THREE.ZeroFactor;
+        break;
+
+      case 1:
+        this.alphaTest = 0.5;
+        this.side = THREE.DoubleSide;
+
+        this.blendSrc = THREE.OneFactor;
+        this.blendDst = THREE.ZeroFactor;
+        this.blendSrcAlpha = THREE.OneFactor;
+        this.blendDstAlpha = THREE.ZeroFactor;
+        break;
+
+      case 2:
+        this.blendSrc = THREE.SrcAlphaFactor;
+        this.blendDst = THREE.OneMinusSrcAlphaFactor;
+        this.blendSrcAlpha = THREE.SrcAlphaFactor;
+        this.blendDstAlpha = THREE.OneMinusSrcAlphaFactor;
+        break;
+
+      case 3:
+        this.blendSrc = THREE.SrcColorFactor;
+        this.blendDst = THREE.DstColorFactor;
+        this.blendSrcAlpha = THREE.SrcAlphaFactor;
+        this.blendDstAlpha = THREE.DstAlphaFactor;
+        break;
+
+      case 4:
+        this.blendSrc = THREE.SrcAlphaFactor;
+        this.blendDst = THREE.OneFactor;
+        this.blendSrcAlpha = THREE.SrcAlphaFactor;
+        this.blendDstAlpha = THREE.OneFactor;
+        break;
+
+      case 5:
+        this.blendSrc = THREE.DstColorFactor;
+        this.blendDst = THREE.ZeroFactor;
+        this.blendSrcAlpha = THREE.DstAlphaFactor;
+        this.blendDstAlpha = THREE.ZeroFactor;
+        break;
+
+      case 6:
+        this.blendSrc = THREE.DstColorFactor;
+        this.blendDst = THREE.SrcColorFactor;
+        this.blendSrcAlpha = THREE.DstAlphaFactor;
+        this.blendDstAlpha = THREE.SrcAlphaFactor;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  loadTextures() {
+    const textureDefs = this.textureDefs;
+
+    const textures = [];
+
+    textureDefs.forEach((textureDef) => {
+      textures.push(this.loadTexture(textureDef));
+    });
+
+    // Update shader uniforms to reflect loaded textures.
+    this.uniforms.textures = { type: 'tv', value: textures };
+    this.uniforms.textureCount = { type: 'i', value: textures.length };
+  }
+
+  loadTexture(textureDef) {
+    let loaded = null;
+
+    switch (textureDef.type) {
+      case 0:
+        // Hardcoded texture
+        loaded = TextureLoader.load(textureDef.filename);
+        loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
+        break;
+      case 11:
+        if (this.skins.skin1) {
+          loaded = TextureLoader.load(this.skins.skin1);
+          loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
+        }
+        break;
+      case 12:
+        if (this.skins.skin2) {
+          loaded = TextureLoader.load(this.skins.skin2);
+          loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
+        }
+        break;
+      case 13:
+        if (this.skins.skin3) {
+          loaded = TextureLoader.load(this.skins.skin3);
+          loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
+        }
+        break;
+      default:
+        break;
+    }
+
+    return loaded;
+  }
+
+  updateSkinTextures(skin1, skin2, skin3) {
+    this.skins.skin1 = skin1;
+    this.skins.skin2 = skin2;
+    this.skins.skin3 = skin3;
+
+    this.loadTextures();
+  }
+
+}
+
+export default M2Material;

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -25,6 +25,15 @@ class M2Material extends THREE.ShaderMaterial {
 
       billboarded: { type: 'f', value: 0.0 },
 
+      // Animated vertex color, uses vector 4 since it can contain alpha channels
+      // TODO: Actually implement vertex color animation
+      animatedVertexColor: { type: 'c', value: new THREE.Color(1.0, 1.0, 1.0) },
+      animatedVertexAlpha: { type: 'f', value: 1.0 },
+
+      // Animated transparencies; these apply per-texture
+      // TODO: Actually implement transparency animation
+      animatedTransparencies: { type: '1fv', value: [1.0, 1.0, 1.0, 1.0] },
+
       // Managed by light manager
       lightModifier: { type: 'f', value: '1.0' },
       ambientLight: { type: 'c', value: new THREE.Color(0.5, 0.5, 0.5) },

--- a/src/lib/pipeline/m2/material/shader.frag
+++ b/src/lib/pipeline/m2/material/shader.frag
@@ -1,0 +1,160 @@
+uniform int fragmentShaderMode;
+
+uniform int textureCount;
+uniform sampler2D textures[4];
+
+varying vec2 vUv;
+
+varying vec3 vertexNormal;
+varying vec3 vertexWorldPosition;
+varying float cameraDistance;
+
+uniform float alphaKey;
+
+uniform float lightModifier;
+uniform vec3 ambientLight;
+uniform vec3 diffuseLight;
+
+uniform float fogModifier;
+uniform float fogStart;
+uniform float fogEnd;
+uniform vec3 fogColor;
+
+vec3 saturate(vec3 value) {
+  vec3 result = clamp(value, 0.0, 1.0);
+  return result;
+}
+
+float saturate(float value) {
+  float result = clamp(value, 0.0, 1.0);
+  return result;
+}
+
+vec4 fragCombinersOpaque(sampler2D texture1, vec2 uv1) {
+  vec4 texture1Color = texture2D(texture1, uv1);
+
+  if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
+    discard;
+  }
+
+  vec4 r0 = texture1Color;
+
+  // TODO: Vertex color?
+  // r0.rgb *= input.color.rgb;
+
+  // TODO: Should this be 1.0? 2.0? Something else?
+  r0.rgb *= 1.0;
+
+  // TODO: Vertex alpha color?
+  // combinedColor.a = input.color.a;
+
+  vec4 outputColor = r0;
+
+  return outputColor;
+}
+
+vec4 fragCombinersOpaqueOpaque(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
+  vec4 texture1Color = texture2D(texture1, uv1);
+  vec4 texture2Color = texture2D(texture2, uv2);
+
+  if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
+    discard;
+  }
+
+  // TODO: Support transparency
+  // textureColor1.a *= transparency.x;
+  // textureColor2.a *= transparency.y;
+
+  vec4 r0 = texture1Color;
+  vec4 r1 = texture2Color;
+  r0.rgb *= r1.rgb;
+
+  // TODO: What's this? Input is vertex, so... vertex color? And only half?
+  // r0.rgb *= input.color.rgb * 0.5f;
+
+  r0.rgb *= 2.0;
+
+  // TODO: Vertex color and alpha?
+  // combinedColor.rgb = r0.rgb;
+  // combinedColor.a = input.color.a;
+
+  vec4 outputColor = r0;
+
+  return outputColor;
+}
+
+vec4 applyDiffuseLighting(vec4 color) {
+  vec3 lightDirection = vec3(-1, 1, -1);
+
+  float light = saturate(dot(vertexNormal, normalize(-lightDirection)));
+
+  vec3 diffusion = diffuseLight.rgb * light;
+  diffusion += ambientLight.rgb;
+  diffusion = saturate(diffusion);
+
+  color.rgb *= diffusion;
+
+  return color;
+}
+
+vec4 applyFog(vec4 color) {
+  // Method A
+  /*
+    float fogRange = fogEnd - fogStart;
+    float fogDepth = (cameraDistance - fogStart) / fogRange;
+    float fogFactor = pow(saturate(fogDepth), 1.5) * fogModifier;
+
+    vec3 fogged = (fogFactor * fogColor.rgb) + ((1.0 - fogFactor) * color.rgb);
+    color.rgb = fogged.rgb;
+  */
+
+  // Method B
+  float fogFactor = (fogEnd - cameraDistance) / (fogEnd - fogStart);
+  fogFactor = fogFactor * fogModifier;
+  fogFactor = clamp(fogFactor, 0.0, 1.0);
+  color.rgb = mix(fogColor.rgb, color.rgb, fogFactor);
+
+  // Ensure alpha channel is gone once a sufficient distance into the fog is reached. Prevents
+  // texture artifacts from overlaying alpha values.
+  if (cameraDistance > fogEnd * 1.5) {
+    color.a = 1.0;
+  }
+
+  return color;
+}
+
+vec4 finalizeColor(vec4 color) {
+  if (lightModifier > 0.0) {
+    color = applyDiffuseLighting(color);
+  }
+
+  if (fogModifier > 0.0) {
+    color = applyFog(color);
+  }
+
+  return color;
+}
+
+void main() {
+  // For some reason, V is inverted?!
+  vec2 uv1 = vec2(vUv[0], -vUv[1]);
+  vec2 uv2 = vec2(vUv[0], -vUv[1]);
+
+  vec4 color;
+
+  // -1 = unknown / unhandled
+  // Stopgap until all shaders are implemented and verified
+
+  if (fragmentShaderMode == -1) {
+    color = texture2D(textures[0], uv1);
+  } else if (fragmentShaderMode == 0) {
+    color = fragCombinersOpaque(textures[0], uv1);
+  } else if (fragmentShaderMode == 1) {
+    color = fragCombinersOpaqueOpaque(textures[0], uv1, textures[1], uv2);
+  }
+
+  // Apply lighting and fog.
+  color = finalizeColor(color);
+
+  gl_FragColor = color;
+}

--- a/src/lib/pipeline/m2/material/shader.frag
+++ b/src/lib/pipeline/m2/material/shader.frag
@@ -3,11 +3,16 @@ uniform int fragmentShaderMode;
 uniform int textureCount;
 uniform sampler2D textures[4];
 
-varying vec2 vUv;
+varying vec2 texture1Coord;
+varying vec2 texture2Coord;
 
-varying vec3 vertexNormal;
-varying vec3 vertexWorldPosition;
 varying float cameraDistance;
+
+varying vec3 vertexWorldNormal;
+
+varying vec4 vertexColor;
+
+uniform float animatedTransparencies[4];
 
 uniform float alphaKey;
 
@@ -30,30 +35,30 @@ float saturate(float value) {
   return result;
 }
 
-vec4 fragCombinersOpaque(sampler2D texture1, vec2 uv1) {
+vec4 fragCombinersWotlkSingle(sampler2D texture1, vec2 uv1) {
   vec4 texture1Color = texture2D(texture1, uv1);
 
   if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
     discard;
   }
 
-  vec4 r0 = texture1Color;
+  vec4 c1 = texture1Color;
 
-  // TODO: Vertex color?
-  // r0.rgb *= input.color.rgb;
+  // Apply animated transparency (defaults to 1.0)
+  c1.a *= animatedTransparencies[0];
 
-  // TODO: Should this be 1.0? 2.0? Something else?
-  r0.rgb *= 1.0;
+  // Blend with vertex color
+  c1.rgb *= (vertexColor.rgb * vertexColor.a);
 
-  // TODO: Vertex alpha color?
-  // combinedColor.a = input.color.a;
+  // Restore full color intensity after blending with vertexColor
+  c1.rgb *= 2.0;
 
-  vec4 outputColor = r0;
+  vec4 outputColor = c1;
 
   return outputColor;
 }
 
-vec4 fragCombinersOpaqueOpaque(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
+vec4 fragCombinersWotlkMulti2(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
   vec4 texture1Color = texture2D(texture1, uv1);
   vec4 texture2Color = texture2D(texture2, uv2);
 
@@ -61,32 +66,83 @@ vec4 fragCombinersOpaqueOpaque(sampler2D texture1, vec2 uv1, sampler2D texture2,
     discard;
   }
 
-  // TODO: Support transparency
-  // textureColor1.a *= transparency.x;
-  // textureColor2.a *= transparency.y;
+  vec4 c1 = texture1Color;
+  vec4 c2 = texture2Color;
 
-  vec4 r0 = texture1Color;
-  vec4 r1 = texture2Color;
-  r0.rgb *= r1.rgb;
+  // Apply animated transparencies (defaults to 1.0)
+  c1.a *= animatedTransparencies[0];
+  c2.a *= animatedTransparencies[1];
 
-  // TODO: What's this? Input is vertex, so... vertex color? And only half?
-  // r0.rgb *= input.color.rgb * 0.5f;
+  // Blend texture alphas
+  c1.a *= c2.a;
 
-  r0.rgb *= 2.0;
+  // Blend with vertex color
+  c1.rgb *= (vertexColor.rgb * vertexColor.a);
 
-  // TODO: Vertex color and alpha?
-  // combinedColor.rgb = r0.rgb;
-  // combinedColor.a = input.color.a;
+  // Restore full color intensity after blending with vertexColor
+  c1.rgb *= 2.0;
 
-  vec4 outputColor = r0;
+  vec4 outputColor = c1;
+
+  return outputColor;
+}
+
+vec4 fragCombinersOpaque(sampler2D texture1, vec2 uv1) {
+  vec4 texture1Color = texture2D(texture1, uv1);
+
+  if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
+    discard;
+  }
+
+  vec4 c1 = texture1Color;
+
+  // Apply animated transparency (defaults to 1.0)
+  c1.a *= animatedTransparencies[0];
+
+  // Blend with vertex color
+  c1.rgb *= (vertexColor.rgb * vertexColor.a);
+
+  // Restore full color intensity after blending with vertexColor
+  c1.rgb *= 2.0;
+
+  vec4 outputColor = c1;
+
+  return outputColor;
+}
+
+vec4 fragCombinersOpaqueAlpha(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
+  vec4 texture1Color = texture2D(texture1, uv1);
+  vec4 texture2Color = texture2D(texture2, uv2);
+
+  if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
+    discard;
+  }
+
+  vec4 c1 = texture1Color;
+  vec4 c2 = texture2Color;
+
+  // Apply animated transparencies (defaults to 1.0)
+  c1.a *= animatedTransparencies[0];
+  c2.a *= animatedTransparencies[1];
+
+  c2.rgb = -c1.rgb + c2.rgb;
+  c1.rgb = c2.a * c2.rgb + c1.rgb;
+
+  // Blend with vertex color
+  c1.rgb *= (vertexColor.rgb * vertexColor.a);
+
+  // Restore full color intensity after blending with vertexColor
+  c1.rgb *= 2.0;
+
+  vec4 outputColor = c1;
 
   return outputColor;
 }
 
 vec4 applyDiffuseLighting(vec4 color) {
-  vec3 lightDirection = vec3(-1, 1, -1);
+  vec3 lightDirection = vec3(1, 1, -1);
 
-  float light = saturate(dot(vertexNormal, normalize(-lightDirection)));
+  float light = saturate(dot(vertexWorldNormal, normalize(-lightDirection)));
 
   vec3 diffusion = diffuseLight.rgb * light;
   diffusion += ambientLight.rgb;
@@ -98,17 +154,6 @@ vec4 applyDiffuseLighting(vec4 color) {
 }
 
 vec4 applyFog(vec4 color) {
-  // Method A
-  /*
-    float fogRange = fogEnd - fogStart;
-    float fogDepth = (cameraDistance - fogStart) / fogRange;
-    float fogFactor = pow(saturate(fogDepth), 1.5) * fogModifier;
-
-    vec3 fogged = (fogFactor * fogColor.rgb) + ((1.0 - fogFactor) * color.rgb);
-    color.rgb = fogged.rgb;
-  */
-
-  // Method B
   float fogFactor = (fogEnd - cameraDistance) / (fogEnd - fogStart);
   fogFactor = fogFactor * fogModifier;
   fogFactor = clamp(fogFactor, 0.0, 1.0);
@@ -136,9 +181,8 @@ vec4 finalizeColor(vec4 color) {
 }
 
 void main() {
-  // For some reason, V is inverted?!
-  vec2 uv1 = vec2(vUv[0], -vUv[1]);
-  vec2 uv2 = vec2(vUv[0], -vUv[1]);
+  vec2 uv1 = vec2(texture1Coord);
+  vec2 uv2 = vec2(texture2Coord);
 
   vec4 color;
 
@@ -148,9 +192,9 @@ void main() {
   if (fragmentShaderMode == -1) {
     color = texture2D(textures[0], uv1);
   } else if (fragmentShaderMode == 0) {
-    color = fragCombinersOpaque(textures[0], uv1);
+    color = fragCombinersWotlkSingle(textures[0], uv1);
   } else if (fragmentShaderMode == 1) {
-    color = fragCombinersOpaqueOpaque(textures[0], uv1, textures[1], uv2);
+    color = fragCombinersWotlkMulti2(textures[0], uv1, textures[1], uv2);
   }
 
   // Apply lighting and fog.

--- a/src/lib/pipeline/m2/material/shader.vert
+++ b/src/lib/pipeline/m2/material/shader.vert
@@ -1,0 +1,89 @@
+precision highp float;
+
+varying vec2 vUv;
+varying vec2 texture0Coord;
+varying vec2 texture1Coord;
+
+varying vec3 vertexNormal;
+varying vec3 vertexWorldPosition;
+varying float cameraDistance;
+
+uniform float billboarded;
+
+#ifdef USE_SKINNING
+	uniform mat4 bindMatrix;
+	uniform mat4 bindMatrixInverse;
+
+	#ifdef BONE_TEXTURE
+		uniform sampler2D boneTexture;
+		uniform int boneTextureWidth;
+		uniform int boneTextureHeight;
+
+		mat4 getBoneMatrix( const in float i ) {
+			float j = i * 4.0;
+			float x = mod( j, float( boneTextureWidth ) );
+			float y = floor( j / float( boneTextureWidth ) );
+
+			float dx = 1.0 / float( boneTextureWidth );
+			float dy = 1.0 / float( boneTextureHeight );
+
+			y = dy * ( y + 0.5 );
+
+			vec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );
+			vec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );
+			vec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );
+			vec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );
+
+			mat4 bone = mat4( v1, v2, v3, v4 );
+
+			return bone;
+		}
+	#else
+		uniform mat4 boneGlobalMatrices[ MAX_BONES ];
+
+		mat4 getBoneMatrix( const in float i ) {
+			mat4 bone = boneGlobalMatrices[ int(i) ];
+			return bone;
+		}
+	#endif
+#endif
+
+void main() {
+  vUv = uv;
+
+  vertexNormal = normal;
+  vertexWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
+  cameraDistance = distance(cameraPosition, vertexWorldPosition);
+
+  // TODO: Use vertexShaderMode to determine coordinates
+  vec2 texture0Coord = vec2(vUv[0], -vUv[1]);
+  vec2 texture1Coord = vec2(vUv[0], -vUv[1]);
+
+  vec3 transformed = vec3(position);
+
+  #ifdef USE_SKINNING
+  	mat4 boneMatX = getBoneMatrix(skinIndex.x);
+  	mat4 boneMatY = getBoneMatrix(skinIndex.y);
+  	mat4 boneMatZ = getBoneMatrix(skinIndex.z);
+  	mat4 boneMatW = getBoneMatrix(skinIndex.w);
+  #endif
+
+  #ifdef USE_SKINNING
+  	vec4 skinVertex = bindMatrix * vec4(transformed, 1.0);
+
+  	vec4 skinned = vec4( 0.0 );
+  	skinned += boneMatX * skinVertex * skinWeight.x;
+  	skinned += boneMatY * skinVertex * skinWeight.y;
+  	skinned += boneMatZ * skinVertex * skinWeight.z;
+  	skinned += boneMatW * skinVertex * skinWeight.w;
+  	skinned = bindMatrixInverse * skinned;
+  #endif
+
+  #ifdef USE_SKINNING
+  	vec4 mvPosition = modelViewMatrix * skinned;
+  #else
+  	vec4 mvPosition = modelViewMatrix * vec4(transformed, 1.0);
+  #endif
+
+  gl_Position = projectionMatrix * mvPosition;
+}

--- a/src/lib/pipeline/m2/material/shader.vert
+++ b/src/lib/pipeline/m2/material/shader.vert
@@ -1,12 +1,17 @@
 precision highp float;
 
-varying vec2 vUv;
-varying vec2 texture0Coord;
 varying vec2 texture1Coord;
+varying vec2 texture2Coord;
 
-varying vec3 vertexNormal;
-varying vec3 vertexWorldPosition;
 varying float cameraDistance;
+
+varying vec3 vertexWorldNormal;
+
+varying vec4 vertexColor;
+uniform vec3 animatedVertexColor;
+uniform float animatedVertexAlpha;
+
+uniform float animatedTransparencies[4];
 
 uniform float billboarded;
 
@@ -49,15 +54,22 @@ uniform float billboarded;
 #endif
 
 void main() {
-  vUv = uv;
+  // For some reason, V is inverted?!
+  // TODO: Use vertexShaderMode to determine coordinates
+  texture1Coord = vec2(uv[0], -uv[1]);
+  texture2Coord = vec2(uv[0], -uv[1]);
 
-  vertexNormal = normal;
-  vertexWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
+  // TODO: Will this be needed in the fragment shader at some point?
+  vec3 vertexWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
+
   cameraDistance = distance(cameraPosition, vertexWorldPosition);
 
-  // TODO: Use vertexShaderMode to determine coordinates
-  vec2 texture0Coord = vec2(vUv[0], -vUv[1]);
-  vec2 texture1Coord = vec2(vUv[0], -vUv[1]);
+  // Account for adjustments (eg. model rotation) in world space
+  // TODO: Do we need to account for skinning?
+  vertexWorldNormal = (modelMatrix * vec4(normal, 0.0)).xyz;
+
+  vertexColor.rgb = animatedVertexColor.rgb * 0.5;
+  vertexColor.a = animatedVertexAlpha;
 
   vec3 transformed = vec3(position);
 

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -8,13 +8,13 @@ class Submesh extends THREE.Group {
     this.useSkinning = opts.useSkinning;
 
     this.rootBone = null;
-    this.isBillboarded = false;
+    this.billboarded = false;
 
     if (this.useSkinning) {
       // Preserve the rootBone for the submesh such that its skin property can be assigned to the
       // first child texture unit mesh.
       this.rootBone = opts.rootBone;
-      this.isBillboarded = opts.rootBone.userData.isBillboarded;
+      this.billboarded = opts.rootBone.userData.billboarded;
 
       // Preserve the skeleton for use in applying texture units.
       this.skeleton = opts.skeleton;
@@ -40,7 +40,7 @@ class Submesh extends THREE.Group {
       const tuMaterial = textureUnits[tuIndex];
 
       // If the submesh is billboarded, flag the material as billboarded.
-      if (this.isBillboarded) {
+      if (this.billboarded) {
         tuMaterial.enableBillboarding();
       }
 

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -1,206 +1,76 @@
 import THREE from 'three';
 
-import Material from '../material';
-
-class Submesh extends THREE.SkinnedMesh {
+class Submesh extends THREE.Group {
 
   constructor(opts) {
-    super(opts.geometry);
+    super();
 
-    opts.rootBone.skin = this;
-
-    this.bind(opts.skeleton);
-
-    this.animations = opts.animations;
+    // Preserve the rootBone for the submesh such that its skin property can be assigned to the
+    // first child texture unit mesh.
+    this.rootBone = opts.rootBone;
     this.isBillboard = opts.rootBone.userData.isBillboard;
-    this.textureUnits = opts.textureUnits;
 
-    this.textureAnimationTrackNames = [];
-
-    this.material = new THREE.MultiMaterial();
-
-    this.skin1 = null;
-    this.skin2 = null;
-    this.skin3 = null;
-
-    this.applyTextureUnits();
+    // Preserve the skeleton and geometry for the submesh.
+    this.skeleton = opts.skeleton;
+    this.geometry = opts.geometry;
   }
 
-  applyTextureUnits() {
-    // Clear out old texture animations and materials in case we're reapplying texture units.
-    this.clearTextureAnimations();
-    this.clearMaterials();
+  // Submeshes get one mesh per texture unit, which allows them to effectively simulate multiple
+  // render passes. Texture unit mesh rendering order should be handled properly by the three.js
+  // renderer.
+  //
+  // For clarity's sake, a texture unit is represented in three.js by a 1:1 coupling of a
+  // SkinnedMesh and a ShaderMaterial. We call them texture units to maintain consistency with
+  // other World of Warcraft projects.
+  //
+  applyTextureUnits(textureUnits) {
+    this.clearTextureUnits();
 
-    // Create materials for each texture unit and add to the group.
-    for (let tuIndex = 0, tuLen = this.textureUnits.length; tuIndex < tuLen; ++tuIndex) {
-      const textureUnit = this.textureUnits[tuIndex];
+    const tuLen = textureUnits.length;
+    for (let tuIndex = 0; tuIndex < tuLen; ++tuIndex) {
+      const tuMaterial = textureUnits[tuIndex];
 
-      const material = this.createMaterial(textureUnit);
+      // Ensure billboarding is handled correctly in the vertex shader.
+      if (this.isBillboard) {
+        tuMaterial.enableBillboarding();
+      }
 
-      this.material.materials.push(material);
+      const tuMesh = new THREE.SkinnedMesh(this.geometry, tuMaterial);
 
-      this.registerTextureAnimations(tuIndex, textureUnit);
-    }
-  }
+      tuMesh.bind(this.skeleton);
 
-  clearTextureAnimations() {
-    this.textureAnimationTrackNames.forEach((trackName) => {
-      this.animations.unregisterTrack(trackName);
-    });
-
-    this.textureAnimationTrackNames = [];
-  }
-
-  clearMaterials() {
-    this.material = new THREE.MultiMaterial();
-  }
-
-  createMaterial(textureUnit) {
-    const { texture, renderFlags } = textureUnit;
-
-    const material = new Material({ skinning: true });
-
-    this.applyTexture(material, texture);
-    this.applyRenderFlags(material, renderFlags.flags);
-    this.applyBlendingMode(material, renderFlags.blendingMode);
-
-    return material;
-  }
-
-  applyTexture(material, texture) {
-    switch (texture.type) {
-      case 0:
-        // Hardcoded texture
-        material.texture = texture.filename;
-        break;
-      case 11:
-        if (this.skin1) {
-          material.texture = this.skin1;
-        }
-        break;
-      case 12:
-        if (this.skin2) {
-          material.texture = this.skin2;
-        }
-        break;
-      case 13:
-        if (this.skin3) {
-          material.texture = this.skin3;
-        }
-        break;
-      default:
-        break;
-    }
-  }
-
-  applyRenderFlags(material, renderFlags) {
-    // Flag 0x04 (no backface culling) and all billboards need double side rendering.
-    if (renderFlags & 0x04 || this.isBillboard) {
-      material.side = THREE.DoubleSide;
+      this.add(tuMesh);
     }
 
-    // Flag 0x04 (no backface culling) and anything with blending mode >= 1 need to obey
-    // alpha values in the material texture.
-    if (renderFlags & 0x04) {
-      material.transparent = true;
-    }
-
-    // Flag 0x10 (no z-buffer write)
-    if (renderFlags & 0x10) {
-      material.depthWrite = false;
-    }
+    this.rootBone.skin = this.children[0];
   }
 
-  applyBlendingMode(material, blendingMode) {
-    if (blendingMode >= 1) {
-      material.transparent = true;
-      material.blending = THREE.CustomBlending;
+  // Remove any existing texture unit child meshes.
+  clearTextureUnits() {
+    const childrenLength = this.children.length;
+    for (let childIndex = 0; childIndex < childrenLength; ++childIndex) {
+      const child = this.children[childIndex];
+      this.remove(child);
     }
 
-    switch (blendingMode) {
-      case 0:
-        material.blending = THREE.NoBlending;
-        material.blendSrc = THREE.OneFactor;
-        material.blendDst = THREE.ZeroFactor;
-        break;
-
-      case 1:
-        material.alphaTest = 0.5;
-        material.side = THREE.DoubleSide;
-
-        material.blendSrc = THREE.OneFactor;
-        material.blendDst = THREE.ZeroFactor;
-        material.blendSrcAlpha = THREE.OneFactor;
-        material.blendDstAlpha = THREE.ZeroFactor;
-        break;
-
-      case 2:
-        material.blendSrc = THREE.SrcAlphaFactor;
-        material.blendDst = THREE.OneMinusSrcAlphaFactor;
-        material.blendSrcAlpha = THREE.SrcAlphaFactor;
-        material.blendDstAlpha = THREE.OneMinusSrcAlphaFactor;
-        break;
-
-      case 3:
-        material.blendSrc = THREE.SrcColorFactor;
-        material.blendDst = THREE.DstColorFactor;
-        material.blendSrcAlpha = THREE.SrcAlphaFactor;
-        material.blendDstAlpha = THREE.DstAlphaFactor;
-        break;
-
-      case 4:
-        material.blendSrc = THREE.SrcAlphaFactor;
-        material.blendDst = THREE.OneFactor;
-        material.blendSrcAlpha = THREE.SrcAlphaFactor;
-        material.blendDstAlpha = THREE.OneFactor;
-        break;
-
-      case 5:
-        material.blendSrc = THREE.DstColorFactor;
-        material.blendDst = THREE.ZeroFactor;
-        material.blendSrcAlpha = THREE.DstAlphaFactor;
-        material.blendDstAlpha = THREE.ZeroFactor;
-        break;
-
-      case 6:
-        material.blendSrc = THREE.DstColorFactor;
-        material.blendDst = THREE.SrcColorFactor;
-        material.blendSrcAlpha = THREE.DstAlphaFactor;
-        material.blendDstAlpha = THREE.SrcAlphaFactor;
-        break;
-
-      default:
-        break;
-    }
+    // If all texture unit meshes are cleared, there is no longer a skin to associate with the
+    // root bone.
+    this.rootBone.skin = null;
   }
 
-  registerTextureAnimations(tuIndex, textureUnit) {
-    if (textureUnit.transparency) {
-      const trackName = this.animations.registerTrack({
-        target: this,
-        property: 'materials[' + tuIndex + '].opacity',
-        animationBlock: textureUnit.transparency,
-        trackType: 'NumberKeyframeTrack',
-
-        valueTransform: function(value) {
-          return value / 32767.0;
-        }
-      });
-
-      this.textureAnimationTrackNames.push(trackName);
-    }
-  }
-
-  reapplyTextureUnits() {
-    this.applyTextureUnits(this.textureUnits);
-  }
-
+  // Update all existing texture unit mesh materials to point to the new skins (textures).
   set displayInfo(displayInfo) {
     const { path } = displayInfo.modelData;
-    this.skin1 = `${path}${displayInfo.skin1}.blp`;
-    this.skin2 = `${path}${displayInfo.skin2}.blp`;
-    this.skin3 = `${path}${displayInfo.skin3}.blp`;
-    this.reapplyTextureUnits();
+
+    const skin1 = `${path}${displayInfo.skin1}.blp`;
+    const skin2 = `${path}${displayInfo.skin2}.blp`;
+    const skin3 = `${path}${displayInfo.skin3}.blp`;
+
+    const childrenLength = this.children.length;
+    for (let childIndex = 0; childIndex < childrenLength; ++childIndex) {
+      const child = this.children[childIndex];
+      child.material.updateSkinTextures(skin1, skin2, skin3);
+    }
   }
 
 }


### PR DESCRIPTION
* M2s no longer overuse ```THREE.SkinnedMesh``` and skinned materials. M2s without bone animations now create regular ```THREE.Mesh``` objects, which do not incur as much cost in the render loop.

* Texture units (which represent render passes in the actual World of Warcraft client) are now given separate materials, 1:1 with the number of units. When submeshes are created for an M2, all applicable texture units are turned into child ```SkinnedMesh``` (or, if not animated, vanilla ```Mesh```) objects, with the aforementioned material attached. As best I can tell, this should ensure proper drawing order between units.

* M2 materials are now full blown ```ShaderMaterial```s.

* Initial work on blending together multiple textures within individual texture units. Currently, only a few shader modes have been implemented. It's still a bit unclear how the game expects different modes to be applied, and what the precise shader logic for each mode should be.

* Added vertex normals. Normals are used to determine light intensity in the diffuse lighting fragment shader logic.

* Added fog, diffuse, and ambient lighting support to M2s. Values are currently hardcoded into the uniforms on the ```M2Material``` class, and will eventually need to migrate to some kind of global lighting manager.

* A root mesh is now created to serve as the appropriate parent for root bones. Root bones are no longer pointlessly reassigned across all submeshes. The root mesh is bound to the skeleton.

* Submeshes are placed as children in the root mesh when created.

* The M2 constructor is now broken up across functions that handle creating the skeleton, geometry, root mesh, and submeshes.

* The use of ```data``` and ```skinData``` within the M2 class is now limited to just the constructor and functions called in the constructor.

* Billboarding now makes use of the ```skin``` property of the bone to find the appropriate parent to pull the model view matrix from.

* When M2s that allow instancing are cloned, their geometries and materials are copied from the original M2. This helps alleviate the burden placed on the GPU by excessive amounts of geometries.