### PR TITLE
Fixed incorrect node_module path assumption made by webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,9 @@ module.exports = {
   resolve: {
     extensions: ['', '.js', '.jsx']
   },
+  resolveLoader: {
+    root: path.join(__dirname, 'node_modules')
+  },
   module: {
     loaders: [
       {


### PR DESCRIPTION
It appears that ```webpack``` was hunting for ```json-loader``` in the Blizzardry directory, instead of in the Wowser directory. This may only be an issue with ```npm >= 3``` (it impacted me, and I'm on ```3.3.12```)